### PR TITLE
Fixed component reporting "playing" when opening kodi

### DIFF
--- a/androidtv11hack/androidtv/base_androidtv.py
+++ b/androidtv11hack/androidtv/base_androidtv.py
@@ -218,6 +218,15 @@ class BaseAndroidTV(BaseTV):  # pylint: disable=too-few-public-methods
                 else:
                     state = constants.STATE_IDLE
 
+            # Kodi
+            elif current_app == constants.APP_KODI:
+                if media_session_state == 2:
+                    state = constants.STATE_PAUSED
+                elif media_session_state == 3:
+                    state = constants.STATE_PLAYING
+                else:
+                    state = constants.STATE_IDLE                    
+                    
             # Get the state from `media_session_state`
             elif media_session_state:
                 if media_session_state == 2:


### PR DESCRIPTION
it appears that kodi will set audio_state to playing when it opens (maybe it just reserves the audio channel or the UI sounds are interpreted as audio playback).

this PR adds extra check for Kodi to ensure androidtv component never gets to the audio state part, similar to the other media apps on the list.