### PR TITLE
also detect focused window by mInputMethodInputTarget

### DIFF
--- a/androidtv11hack/constants.py
+++ b/androidtv11hack/constants.py
@@ -37,7 +37,7 @@ CMD_PARSE_CURRENT_APP = '{ CURRENT_APP=${CURRENT_APP%%/*}; CURRENT_APP=${CURRENT
 
 #: Assign focused application identifier to ``CURRENT_APP`` variable
 ## Android < 10 CMD_DEFINE_CURRENT_APP_VARIABLE = "CURRENT_APP=$(dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp') && " + CMD_PARSE_CURRENT_APP
-CMD_DEFINE_CURRENT_APP_VARIABLE = "CURRENT_APP=$(dumpsys window windows | grep -E 'mInputMethodTarget in display# 0|mCurrentFocus=' | grep -o Window{.*}) && " + CMD_PARSE_CURRENT_APP
+CMD_DEFINE_CURRENT_APP_VARIABLE = "CURRENT_APP=$(dumpsys window windows | grep -E -m 1 'mInputMethod(Input)?Target in display# 0|mCurrentFocus=' | grep -o Window{.*}) && " + CMD_PARSE_CURRENT_APP
 
 #: Output identifier for current/focused application
 CMD_CURRENT_APP = CMD_DEFINE_CURRENT_APP_VARIABLE + ' && echo $CURRENT_APP'


### PR DESCRIPTION
I've noticed that my Nvidia Shield will sometimes completely omit `mInputMethodTarget` in the dumpsys window output. For example:

```
WINDOW MANAGER WINDOWS (dumpsys window windows)
  Window #0 Window{5c08713 u0 org.xbmc.kodi/org.xbmc.kodi.Main}:
    mDisplayId=0 rootTaskId=1290 mSession=Session{40887aa 10484:u0a10087} mClient=android.os.BinderProxy@4266202
    mOwnerUid=10087 showForAllUsers=false package=org.xbmc.kodi appop=NONE
    mAttrs={(0,0)(fillxfill) sim={adjust=resize} ty=BASE_APPLICATION fmt=TRANSLUCENT wanim=0x1030001 preferredRefreshRate=60.000004 preferredDisplayMode=21 sysuil=true
      fl=LAYOUT_IN_SCREEN LAYOUT_INSET_DECOR SPLIT_TOUCH HARDWARE_ACCELERATED
      pfl=FORCE_DRAW_STATUS_BAR_BACKGROUND FIT_INSETS_CONTROLLED
      vsysui=HIDE_NAVIGATION FULLSCREEN LAYOUT_STABLE LAYOUT_HIDE_NAVIGATION LAYOUT_FULLSCREEN IMMERSIVE_STICKY
      bhv=SHOW_TRANSIENT_BARS_BY_SWIPE
      fitSides=}
    Requested w=1920 h=1080 mLayoutSeq=171
    mBaseLayer=21000 mSubLayer=0    mToken=ActivityRecord{3f18031 u0 org.xbmc.kodi/.Main t1290}
    mActivityRecord=ActivityRecord{3f18031 u0 org.xbmc.kodi/.Main t1290}
    mAppDied=false    drawnStateEvaluated=true    mightAffectAllDrawn=true
    mViewVisibility=0x0 mHaveFrame=true mObscured=false
    mSeq=1 mSystemUiVisibility=0x1700
    mGivenContentInsets=[0,0][0,0] mGivenVisibleInsets=[0,0][0,0]
    mFullConfiguration={1.0 ?mcc?mnc [en_GB] ldltr sw540dp w960dp h540dp 320dpi lrg long hdr widecg land television -touch -keyb/v/h dpad/v winConfig={ mBounds=Rect(0, 0 - 1920, 1080) mAppBounds=Rect(0, 0 - 1920, 1080) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=standard mAlwaysOnTop=undefined mRotation=ROTATION_0} s.4}
    mLastReportedConfiguration={1.0 ?mcc?mnc [en_GB] ldltr sw540dp w960dp h540dp 320dpi lrg long hdr widecg land television -touch -keyb/v/h dpad/v winConfig={ mBounds=Rect(0, 0 - 1920, 1080) mAppBounds=Rect(0, 0 - 1920, 1080) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=standard mAlwaysOnTop=undefined mRotation=ROTATION_0} s.4}
    mHasSurface=true isReadyForDisplay()=true mWindowRemovalAllowed=false
    Frames: containing=[0,0][1920,1080] parent=[0,0][1920,1080]
        display=[0,0][1920,1080]
        content=[0,0][1920,1080] visible=[0,0][1920,1080]
        decor=[0,0][1920,1080]
    mFrame=[0,0][1920,1080] last=[0,0][1920,1080]
     cutout=DisplayCutout{insets=Rect(0, 0 - 0, 0) waterfall=Insets{left=0, top=0, right=0, bottom=0} boundingRect={Bounds=[Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0)]}} last=DisplayCutout{insets=Rect(0, 0 - 0, 0) waterfall=Insets{left=0, top=0, right=0, bottom=0} boundingRect={Bounds=[Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0)]}}
    Cur insets: content=[0,0][0,0] visible=[0,0][0,0] stable=[0,0][0,0]    Lst insets: content=[0,0][0,0] visible=[0,0][0,0] stable=[0,0][0,0]
     surface=[0,0][0,0]
    WindowStateAnimator{609630c org.xbmc.kodi/org.xbmc.kodi.Main}:
      mSurface=Surface(name=org.xbmc.kodi/org.xbmc.kodi.Main)/@0x5750455
      Surface: shown=true layer=0 alpha=1.0 rect=(0.0,0.0) 1920 x 1080 transform=(1.0, 0.0, 1.0, 0.0)
      mDrawState=HAS_DRAWN       mLastHidden=false
      mEnterAnimationPending=false      mSystemDecorRect=[0,0][1920,1080] mLastClipRect=[0,0][1920,1080]
    mForceSeamlesslyRotate=false seamlesslyRotate: pending=null finishedFrameNumber=0
    isOnScreen=true
    isVisible=true
    mRequestedInsetsState: InsetsState: {mDisplayFrame=Rect(0, 0 - 0, 0), mSources= {  }
  Window #1 Window{9911dd4 u0 com.android.systemui.ImageWallpaper}:
    mDisplayId=0 rootTaskId=1 mSession=Session{e23b728 3719:u0a10037} mClient=android.os.BinderProxy@f4e0727
    mOwnerUid=10037 showForAllUsers=false package=com.android.systemui appop=NONE
    mAttrs={(0,0)(1920x1920) gr=TOP START CENTER layoutInDisplayCutoutMode=always ty=WALLPAPER fmt=RGBX_8888 wanim=0x103030e
      fl=NOT_FOCUSABLE NOT_TOUCHABLE LAYOUT_IN_SCREEN LAYOUT_NO_LIMITS SCALED LAYOUT_INSET_DECOR}
    Requested w=64 h=64 mLayoutSeq=27
    mIsImWindow=false mIsWallpaper=true mIsFloatingLayer=true mWallpaperVisible=false
    mBaseLayer=11000 mSubLayer=0    mToken=WallpaperWindowToken{85b1509 token=android.os.Binder@6373610}
    mViewVisibility=0x0 mHaveFrame=true mObscured=false
    mSeq=0 mSystemUiVisibility=0x0
    mGivenContentInsets=[0,0][0,0] mGivenVisibleInsets=[0,0][0,0]
    mFullConfiguration={1.0 ?mcc?mnc [en_GB] ldltr sw540dp w960dp h540dp 320dpi lrg long hdr widecg land television -touch -keyb/v/h dpad/v winConfig={ mBounds=Rect(0, 0 - 1920, 1080) mAppBounds=Rect(0, 0 - 1920, 1080) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.9}
    mLastReportedConfiguration={1.0 ?mcc?mnc [en_GB] ldltr sw540dp w960dp h540dp 320dpi lrg long hdr widecg land television -touch -keyb/v/h dpad/v winConfig={ mBounds=Rect(0, 0 - 1920, 1080) mAppBounds=Rect(0, 0 - 1920, 1080) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.9}
    mHasSurface=true isReadyForDisplay()=false mWindowRemovalAllowed=false
    Frames: containing=[0,0][1920,1080] parent=[0,0][1920,1080]
        display=[-10000,-10000][10000,10000]
        content=[0,0][1920,1080] visible=[0,0][1920,1080]
        decor=[0,0][1920,1080]
    mFrame=[0,0][1920,1920] last=[0,0][1920,1920]
     cutout=DisplayCutout{insets=Rect(0, 0 - 0, 0) waterfall=Insets{left=0, top=0, right=0, bottom=0} boundingRect={Bounds=[Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0)]}} last=DisplayCutout{insets=Rect(0, 0 - 0, 0) waterfall=Insets{left=0, top=0, right=0, bottom=0} boundingRect={Bounds=[Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0)]}}
    Cur insets: content=[0,0][0,840] visible=[0,0][0,840] stable=[0,0][0,840]    Lst insets: content=[0,0][0,840] visible=[0,0][0,840] stable=[0,0][0,840]
     surface=[0,0][0,0]
    WindowStateAnimator{45a7a05 com.android.systemui.ImageWallpaper}:
      mSurface=Surface(name=com.android.systemui.ImageWallpaper)/@0x91aa5a
      Surface: shown=false layer=0 alpha=0.0 rect=(-96.0,-516.0) 64 x 64 transform=(33.0, 0.0, 33.0, 0.0)
      mDrawState=HAS_DRAWN       mLastHidden=true
      mEnterAnimationPending=false      mSystemDecorRect=[0,0][0,0] mLastClipRect=[0,0][0,0]
    mLastFreezeDuration=+17s394ms
    mForceSeamlesslyRotate=false seamlesslyRotate: pending=null finishedFrameNumber=0
    mHScale=30.0 mVScale=30.0
    mWallpaperX=0.0 mWallpaperY=0.5
    mWallpaperZoomOut=0.0
    isOnScreen=true
    isVisible=false
    mRequestedInsetsState: InsetsState: {mDisplayFrame=Rect(0, 0 - 0, 0), mSources= {  }
  mGlobalConfiguration={1.0 ?mcc?mnc [en_GB] ldltr sw540dp w960dp h540dp 320dpi lrg long hdr widecg land television -touch -keyb/v/h dpad/v winConfig={ mBounds=Rect(0, 0 - 1920, 1080) mAppBounds=Rect(0, 0 - 1920, 1080) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.9}
  mHasPermanentDpad=true
  mTopFocusedDisplayId=0
  mInputMethodInputTarget in display# 0 Window{5c08713 u0 org.xbmc.kodi/org.xbmc.kodi.Main}
  inputMethodControlTarget in display# 0 Window{5c08713 u0 org.xbmc.kodi/org.xbmc.kodi.Main}
  mInTouchMode=false
  mLastDisplayFreezeDuration=0 due to Window{9911dd4 u0 com.android.systemui.ImageWallpaper}
  mLastWakeLockHoldingWindow=null mLastWakeLockObscuringWindow=null
  mHighResTaskSnapshotScale=1.0
  SnapshotCache
  mTraversalScheduled=false
  mHoldScreenWindow=null
  mObscuringWindow=null
  mSystemBooted=true mDisplayEnabled=true
  mTransactionSequence=223
  mDisplayFrozen=false windows=0 client=false apps=0  mRotation=0  mLastOrientation=6
 waitingForConfig=false
  Animation settings: disabled=false window=1.0 transition=1.0 animator=1.0
  PolicyControl.sImmersiveStatusFilter=null
  PolicyControl.sImmersiveNavigationFilter=null
  PolicyControl.sImmersivePreconfirmationsFilter=null
```

Note that `mInputMethodTarget` is missing. It appears to come back later, but in the meantime component does not detect current app and consequently does not properly detect playback mode.

I have no idea why this happens, but it appears that `mInputMethodInputTarget` is still there when it happens, so I've modified the regex to fall back on this line.